### PR TITLE
Add optimized-checkboxes, no-ticks and no-cb-borders

### DIFF
--- a/client/src/components/CheckboxGrid.tsx
+++ b/client/src/components/CheckboxGrid.tsx
@@ -92,7 +92,6 @@ class CheckboxRow extends Component<CheckboxRowProps> {
 								type="checkbox"
 								className={
                                     `${checkboxStyle} ${isHighlighted(idx)} ${tickMarkToggle}`
-                                    .split(" ").filter( x => x !== '' ).join(' ')
                                 }
 								onChange={() => this.onChange(idx)}
 								ref={this.checkboxRefs[i]}

--- a/client/src/components/CheckboxGrid.tsx
+++ b/client/src/components/CheckboxGrid.tsx
@@ -1,7 +1,7 @@
 import { elementScroll, observeElementOffset, observeElementRect, Virtualizer } from "@tanstack/virtual-core";
 import { Component, createRef, InfernoNode, RefObject } from "inferno";
 import { BitmapClient, CHUNK_SIZE } from "../client";
-import { getCheckboxStylePreference, getTickMarkVisible } from "../utils";
+import * as utils from "../utils";
 
 const CHECKBOX_SIZE = 30;
 
@@ -15,6 +15,7 @@ interface CheckboxRowProps {
 	client: BitmapClient;
     checkboxStylePreference: string;
     hasTickMark: boolean;
+    hasTickMarkBorders: boolean
 }
 
 class CheckboxRow extends Component<CheckboxRowProps> {
@@ -74,6 +75,7 @@ class CheckboxRow extends Component<CheckboxRowProps> {
         const checkboxStyle= (props.checkboxStylePreference === "reduced") ? "reduced" : "default";
         const isHighlighted = (idx: number) => props.client.highlightedIndex === idx ? "highlighted" : ""
         const tickMarkToggle = (props.hasTickMark) ? "" : "noTick";
+        const tickMarkBorderToggle = (props.hasTickMarkBorders) ? "" : "noBorder"
 
 		return (
 			<div
@@ -91,7 +93,7 @@ class CheckboxRow extends Component<CheckboxRowProps> {
 							<input
 								type="checkbox"
 								className={
-                                    `${checkboxStyle} ${isHighlighted(idx)} ${tickMarkToggle}`
+                                    `${checkboxStyle} ${isHighlighted(idx)} ${tickMarkToggle} ${tickMarkBorderToggle}`
                                 }
 								onChange={() => this.onChange(idx)}
 								ref={this.checkboxRefs[i]}
@@ -254,8 +256,9 @@ export class CheckboxGrid extends Component<CheckboxGridProps, CheckboxGridState
 									{...state}
 									index={virtualItem.index}
 									count={this.getCount(virtualItem.index * state.itemsPerRow)}
-                                    checkboxStylePreference={getCheckboxStylePreference()}
-                                    hasTickMark={getTickMarkVisible()}
+                                    checkboxStylePreference={utils.getCheckboxStylePreference()}
+                                    hasTickMark={utils.getTickMarkVisible()}
+                                    hasTickMarkBorders={utils.getTickMarkBorderVisible()}
 								/>
 							</div>
 						);

--- a/client/src/components/CheckboxGrid.tsx
+++ b/client/src/components/CheckboxGrid.tsx
@@ -1,6 +1,7 @@
 import { elementScroll, observeElementOffset, observeElementRect, Virtualizer } from "@tanstack/virtual-core";
 import { Component, createRef, InfernoNode, RefObject } from "inferno";
 import { BitmapClient, CHUNK_SIZE } from "../client";
+import { getCheckboxStylePreference, getTickMarkVisible } from "../utils";
 
 const CHECKBOX_SIZE = 30;
 
@@ -12,6 +13,8 @@ interface CheckboxRowProps {
 	itemsPerRow: number;
 	checkboxSize: number;
 	client: BitmapClient;
+    checkboxStylePreference: string;
+    hasTickMark: boolean;
 }
 
 class CheckboxRow extends Component<CheckboxRowProps> {
@@ -19,7 +22,6 @@ class CheckboxRow extends Component<CheckboxRowProps> {
 
 	constructor(props: CheckboxRowProps) {
 		super(props);
-
 		this.checkboxRefs = [...Array(props.count)].map(() => createRef());
 		this.bitmapChanged = this.bitmapChanged.bind(this);
 	}
@@ -67,7 +69,11 @@ class CheckboxRow extends Component<CheckboxRowProps> {
 	}
 
 	render(props: CheckboxRowProps): InfernoNode {
+
 		const baseIdx = props.client.chunkIndex * CHUNK_SIZE + props.index * props.itemsPerRow;
+        const checkboxStyle= (props.checkboxStylePreference === "reduced") ? "reduced" : "default";
+        const isHighlighted = (idx: number) => props.client.highlightedIndex === idx ? "highlighted" : ""
+        const tickMarkToggle = (props.hasTickMark) ? "" : "noTick";
 
 		return (
 			<div
@@ -84,7 +90,10 @@ class CheckboxRow extends Component<CheckboxRowProps> {
 						<div className="checkbox">
 							<input
 								type="checkbox"
-								className={props.client.highlightedIndex === idx ? "highlighted" : undefined}
+								className={
+                                    `${checkboxStyle} ${isHighlighted(idx)} ${tickMarkToggle}`
+                                    .split(" ").filter( x => x !== '' ).join(' ')
+                                }
 								onChange={() => this.onChange(idx)}
 								ref={this.checkboxRefs[i]}
 								checked={props.client.isChecked(idx)}
@@ -246,6 +255,8 @@ export class CheckboxGrid extends Component<CheckboxGridProps, CheckboxGridState
 									{...state}
 									index={virtualItem.index}
 									count={this.getCount(virtualItem.index * state.itemsPerRow)}
+                                    checkboxStylePreference={getCheckboxStylePreference()}
+                                    hasTickMark={getTickMarkVisible()}
 								/>
 							</div>
 						);

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { Component, FormEvent } from "inferno";
 import { BITMAP_SIZE, BitmapClient, CHUNK_COUNT, CHUNK_SIZE } from "../client";
-import { applyTheme, downloadUint8Array, getCurrentTheme, debug, themes } from "../utils";
+import { applyTheme, downloadUint8Array, getCurrentTheme, debug, themes, getCheckboxStylePreference, setCheckboxStylePreference, getTickMarkVisible, setTickMarkVisible } from "../utils";
 import { Spinner } from "./Spinner";
 
 interface GoToCheckboxFormProps {
@@ -97,6 +97,86 @@ class ThemePicker extends Component<object, ThemePickerState> {
 	}
 }
 
+interface CheckboxStylePreferenceState {
+    preference: string;
+}
+
+class CheckboxStylePreference extends Component<object, CheckboxStylePreferenceState> {
+    constructor(props: object) {
+		super(props);
+
+		this.state = {
+			preference: getCheckboxStylePreference(),
+		};
+	}
+
+	setPreference(isChecked: boolean): void {
+
+        const preference = (isChecked) ? "reduced" : "default";
+        setCheckboxStylePreference( preference );
+        this.setState({ preference });
+	}
+
+	render(_props: object, state: CheckboxStylePreferenceState) {
+		return (
+			<div className="flex gap-2 mb-2">
+				<b>Reduced checkbox style:</b>
+				<input
+                    type="checkbox"
+					value={state.preference}
+					onChange={(e) => this.setPreference( e.target.checked )}
+                    checked={this.state?.preference === "reduced"}
+					$HasNonKeyedChildren
+				>
+					{themes.map((theme) => (
+						<option value={theme.id}>{theme.label}</option>
+					))}
+				</input>
+			</div>
+		);
+	}
+}
+
+interface TickMarkVisibilityState {
+    hasTick: boolean;
+}
+
+class TickMarkVisibility extends Component<object, TickMarkVisibilityState> {
+    constructor(props: object) {
+		super(props);
+
+		this.state = {
+			hasTick: getTickMarkVisible(),
+		};
+	}
+
+	setPreference(isChecked: boolean): void {
+
+        const hasTick = !isChecked;
+        setTickMarkVisible( hasTick );
+        this.setState({ hasTick });
+	}
+
+	render(_props: object, state: TickMarkVisibilityState) {
+		return (
+			<div className="flex gap-2 mb-2">
+				<b>Remove ticks (✔):</b>
+				<input
+                    type="checkbox"
+					value={state.hasTick.toString()}
+					onChange={(e) => this.setPreference( e.target.checked )}
+                    checked={!this.state?.hasTick}
+					$HasNonKeyedChildren
+				>
+					{themes.map((theme) => (
+						<option value={theme.id}>{theme.label}</option>
+					))}
+				</input>
+			</div>
+		);
+	}
+}
+
 interface OverlayProps {
 	client: BitmapClient;
 	close: () => void;
@@ -141,6 +221,8 @@ class Overlay extends Component<OverlayProps> {
 					<GoToCheckboxForm client={props.client} close={props.close} />
 
 					<ThemePicker />
+                    <CheckboxStylePreference />
+                    <TickMarkVisibility />
 
 					<p>
 						A stupid project by <a href="https://github.com/alula">Alula</a>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { Component, FormEvent } from "inferno";
 import { BITMAP_SIZE, BitmapClient, CHUNK_COUNT, CHUNK_SIZE } from "../client";
-import { applyTheme, downloadUint8Array, getCurrentTheme, debug, themes, getCheckboxStylePreference, setCheckboxStylePreference, getTickMarkVisible, setTickMarkVisible } from "../utils";
+import * as utils from "../utils";
 import { Spinner } from "./Spinner";
 
 interface GoToCheckboxFormProps {
@@ -69,12 +69,12 @@ class ThemePicker extends Component<object, ThemePickerState> {
 		super(props);
 
 		this.state = {
-			theme: getCurrentTheme(),
+			theme: utils.getCurrentTheme(),
 		};
 	}
 
 	setTheme(theme: string): void {
-		applyTheme(theme);
+		utils.applyTheme(theme);
 		this.setState({ theme });
 	}
 
@@ -88,7 +88,7 @@ class ThemePicker extends Component<object, ThemePickerState> {
 					onChange={(e) => this.setTheme(e.target.value)}
 					$HasNonKeyedChildren
 				>
-					{themes.map((theme) => (
+					{utils.themes.map((theme) => (
 						<option value={theme.id}>{theme.label}</option>
 					))}
 				</select>
@@ -106,14 +106,14 @@ class CheckboxStylePreference extends Component<object, CheckboxStylePreferenceS
 		super(props);
 
 		this.state = {
-			preference: getCheckboxStylePreference(),
+			preference: utils.getCheckboxStylePreference(),
 		};
 	}
 
 	setPreference(isChecked: boolean): void {
 
         const preference = (isChecked) ? "reduced" : "default";
-        setCheckboxStylePreference( preference );
+        utils.setCheckboxStylePreference( preference );
         this.setState({ preference: preference });
 	}
 
@@ -128,7 +128,7 @@ class CheckboxStylePreference extends Component<object, CheckboxStylePreferenceS
                     checked={this.state?.preference === "reduced"}
 					$HasNonKeyedChildren
 				>
-					{themes.map((theme) => (
+					{utils.themes.map((theme) => (
 						<option value={theme.id}>{theme.label}</option>
 					))}
 				</input>
@@ -146,14 +146,14 @@ class TickMarkVisibility extends Component<object, TickMarkVisibilityState> {
 		super(props);
 
 		this.state = {
-			hasTick: getTickMarkVisible(),
+			hasTick: utils.getTickMarkVisible(),
 		};
 	}
 
 	setPreference(isChecked: boolean): void {
 
         const hasTick = !isChecked;
-        setTickMarkVisible( hasTick );
+        utils.setTickMarkVisible( hasTick );
         this.setState({ hasTick: hasTick });
 	}
 
@@ -168,7 +168,47 @@ class TickMarkVisibility extends Component<object, TickMarkVisibilityState> {
                     checked={!this.state?.hasTick}
 					$HasNonKeyedChildren
 				>
-					{themes.map((theme) => (
+					{utils.themes.map((theme) => (
+						<option value={theme.id}>{theme.label}</option>
+					))}
+				</input>
+			</div>
+		);
+	}
+}
+
+interface TickMarkBorderVisibilityState {
+    hasBorder: boolean;
+}
+
+class TickMarkBorderVisibility extends Component<object, TickMarkBorderVisibilityState> {
+    constructor(props: object) {
+		super(props);
+
+		this.state = {
+			hasBorder: utils.getTickMarkBorderVisible(),
+		};
+	}
+
+	setPreference(isChecked: boolean): void {
+
+        const hasBorder = !isChecked;
+        utils.setTickMarkBorderVisible( hasBorder );
+        this.setState({ hasBorder: hasBorder });
+	}
+
+	render(_props: object, state: TickMarkBorderVisibilityState) {
+		return (
+			<div className="flex gap-2 mb-2">
+				<b>Remove checkmark borders:</b>
+				<input
+                    type="checkbox"
+					value={state.hasBorder.toString()}
+					onChange={(e) => this.setPreference( e.target.checked )}
+                    checked={!this.state?.hasBorder}
+					$HasNonKeyedChildren
+				>
+					{utils.themes.map((theme) => (
 						<option value={theme.id}>{theme.label}</option>
 					))}
 				</input>
@@ -194,7 +234,7 @@ class ElementVisibilityToggler extends Component<object, ElementVisibilityToggle
 	toggleVisibility(): void {
     
         const isToggled = Boolean(this.state?.isVisible);
-        setTickMarkVisible( !isToggled );
+        utils.setTickMarkVisible( !isToggled );
         this.setState({ isVisible: !isToggled });
 	}
 
@@ -228,13 +268,13 @@ class Overlay extends Component<OverlayProps> {
 	}
 
 	#toggleDebug(): void {
-		debug.value = !debug.value;
+		utils.debug.value = !utils.debug.value;
 	}
 
 	#downloadPage(): void {
 		const data = this.props.client.getUint8Array();
 		const filename = `state-${this.props.client.chunkIndex}.bin`;
-		downloadUint8Array(data, filename);
+		utils.downloadUint8Array(data, filename);
 	}
 
 	#onDebugChange = () => {
@@ -242,11 +282,11 @@ class Overlay extends Component<OverlayProps> {
 	};
 
 	componentDidMount(): void {
-		debug.subscribe(this.#onDebugChange);
+		utils.debug.subscribe(this.#onDebugChange);
 	}
 
 	componentWillUnmount(): void {
-		debug.unsubscribe(this.#onDebugChange);
+		utils.debug.unsubscribe(this.#onDebugChange);
 	}
 
 	render(props: OverlayProps) {
@@ -266,6 +306,7 @@ class Overlay extends Component<OverlayProps> {
 
                         <CheckboxStylePreference />
                         <TickMarkVisibility />
+                        <TickMarkBorderVisibility />
 
                     </ElementVisibilityToggler>
 
@@ -298,7 +339,7 @@ class Overlay extends Component<OverlayProps> {
 						</span>
 					</p>
 
-					{debug.value && (
+					{utils.debug.value && (
 						<div>
 							you found the hidden debug menu!
 							<button className="btn" onClick={() => this.#downloadPage()}>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -114,7 +114,7 @@ class CheckboxStylePreference extends Component<object, CheckboxStylePreferenceS
 
         const preference = (isChecked) ? "reduced" : "default";
         setCheckboxStylePreference( preference );
-        this.setState({ preference });
+        this.setState({ preference: preference });
 	}
 
 	render(_props: object, state: CheckboxStylePreferenceState) {
@@ -154,7 +154,7 @@ class TickMarkVisibility extends Component<object, TickMarkVisibilityState> {
 
         const hasTick = !isChecked;
         setTickMarkVisible( hasTick );
-        this.setState({ hasTick });
+        this.setState({ hasTick: hasTick });
 	}
 
 	render(_props: object, state: TickMarkVisibilityState) {
@@ -173,6 +173,46 @@ class TickMarkVisibility extends Component<object, TickMarkVisibilityState> {
 					))}
 				</input>
 			</div>
+		);
+	}
+}
+
+interface ElementVisibilityTogglerState {
+    isVisible: boolean;
+}
+
+class ElementVisibilityToggler extends Component<object, ElementVisibilityTogglerState> {
+
+    constructor(props: object) {
+		super(props);
+
+		this.state = {
+			isVisible: false,
+		};
+	}
+
+	toggleVisibility(): void {
+    
+        const isToggled = Boolean(this.state?.isVisible);
+        setTickMarkVisible( !isToggled );
+        this.setState({ isVisible: !isToggled });
+	}
+
+	render(_props: object, state: ElementVisibilityTogglerState) {
+		return (
+            <>
+            <div>
+                <div onClick={() => this.toggleVisibility()} style={{ cursor: 'pointer'}} className="flex gap-2 mb-2">
+                    {state.isVisible ? "▼ Hide Preferences" : "▶ Show Preferences"}
+                </div>
+                {state.isVisible && (
+                    <div className="preferencesSection">
+                        {this.props.children}
+                    </div>
+                )}
+            </div>
+            </>
+
 		);
 	}
 }
@@ -221,8 +261,13 @@ class Overlay extends Component<OverlayProps> {
 					<GoToCheckboxForm client={props.client} close={props.close} />
 
 					<ThemePicker />
-                    <CheckboxStylePreference />
-                    <TickMarkVisibility />
+
+                    <ElementVisibilityToggler>
+
+                        <CheckboxStylePreference />
+                        <TickMarkVisibility />
+
+                    </ElementVisibilityToggler>
 
 					<p>
 						A stupid project by <a href="https://github.com/alula">Alula</a>

--- a/client/src/style/style.css
+++ b/client/src/style/style.css
@@ -95,22 +95,28 @@ main {
 	clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
 	background-color: var(--secondary-2);
 }
-.checkbox input::before.default {
-    transform: scale(0);
-    transition: transform 0.2s;
-}
 
 .checkbox input:checked {
 	background-color: var(--active);
 	border-color: var(--active);
 }
 
-.checkbox input.default:checked::before {
+.checkbox input::before.default {
+    transition: transform 0.2s;
+}
+
+.checkbox input::before {
+    transform: scale(0);
+}
+
+.checkbox input:checked::before {
 	transform: scale(1);
 }
+
 .checkbox input.noTick:checked::before {
     display: none;
 }
+
 .checkbox input.noTick:not(:checked)::before {
     display: none;
 }

--- a/client/src/style/style.css
+++ b/client/src/style/style.css
@@ -108,6 +108,9 @@ main {
 .checkbox input.noTick:checked::before {
     display: none;
 }
+.checkbox input.noTick:not(:checked)::before {
+    display: none;
+}
 
 .checkbox input:hover.default {
 	background-color: var(--surface-1);

--- a/client/src/style/style.css
+++ b/client/src/style/style.css
@@ -71,11 +71,14 @@ main {
 	color: currentColor;
 	width: 0.95em;
 	height: 0.95em;
-	border: 0.08em solid var(--surface-2);
-	border-radius: 0.12em;
 
 	display: grid;
 	place-content: center;
+}
+
+.checkbox input:not(.noBorder) {
+    border: 0.08em solid var(--surface-2);
+	border-radius: 0.12em;
 }
 
 .checkbox input.default {

--- a/client/src/style/style.css
+++ b/client/src/style/style.css
@@ -76,10 +76,12 @@ main {
 
 	display: grid;
 	place-content: center;
+}
 
-	transition:
-		background-color 0.2s,
-		border-color 0.2s;
+.checkbox input.default {
+    transition:
+    background-color 0.2s,
+    border-color 0.2s;
 }
 
 .checkbox input::before {
@@ -89,8 +91,10 @@ main {
 	height: 0.7em;
 	clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
 	background-color: var(--secondary-2);
-	transform: scale(0);
-	transition: transform 0.2s;
+}
+.checkbox input::before.default {
+    transform: scale(0);
+    transition: transform 0.2s;
 }
 
 .checkbox input:checked {
@@ -98,25 +102,28 @@ main {
 	border-color: var(--active);
 }
 
-.checkbox input:checked::before {
+.checkbox input.default:checked::before {
 	transform: scale(1);
 }
+.checkbox input.noTick:checked::before {
+    display: none;
+}
 
-.checkbox input:hover {
+.checkbox input:hover.default {
 	background-color: var(--surface-1);
 }
 
-.checkbox input:checked:hover {
+.checkbox input:checked:hover.default {
 	background-color: var(--active);
 	border-color: var(--text);
 }
 
-.checkbox input:focus {
+.checkbox input:focus.default {
 	outline: none;
 	box-shadow: 0 0 0 2px var(--subtext-0);
 }
 
-.checkbox input.highlighted {
+.checkbox input.highlighted.default {
 	animation: highlight 5s ease-out;
 }
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,3 +1,5 @@
+import { renderApp } from "./App";
+
 export class Observable<T> {
 	#value: T;
 	#listeners: Set<(value: T) => void>;
@@ -28,6 +30,8 @@ export class Observable<T> {
 
 const themeStorageKey = "1bcb__theme";
 const debugStorageKey = "1bcb__debug";
+const tickMarkVisibleKey = "1bcb__hasTick";
+const checkboxStylePreferenceKey = "1bcb__checkboxStyle";
 
 export const themes = [
 	{ id: "ctp-mocha", label: "Catppuccin Dark" },
@@ -50,6 +54,24 @@ export function getCurrentTheme(): string {
 
 export function applyThemeFromStorage(): void {
 	applyTheme(getCurrentTheme());
+}
+
+export function setCheckboxStylePreference(preference: string): void {
+    localStorage.setItem(checkboxStylePreferenceKey, preference);
+    renderApp();
+}
+
+export function getCheckboxStylePreference(): string {
+	return localStorage.getItem(checkboxStylePreferenceKey) || "default";
+}
+
+export function setTickMarkVisible(hasTick: boolean): void {
+    localStorage.setItem(tickMarkVisibleKey, hasTick.toString());
+    renderApp();
+}
+
+export function getTickMarkVisible(): boolean {
+    return localStorage.getItem(tickMarkVisibleKey) === "true";
 }
 
 export const debug = new Observable(typeof window !== "undefined" && localStorage.getItem(debugStorageKey) === "true");

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -30,8 +30,7 @@ export class Observable<T> {
 
 const themeStorageKey = "1bcb__theme";
 const debugStorageKey = "1bcb__debug";
-const tickMarkVisibleKey = "1bcb__hasTick";
-const checkboxStylePreferenceKey = "1bcb__checkboxStyle";
+const preferencesStorageKey = "1bcb__preferences";
 
 export const themes = [
 	{ id: "ctp-mocha", label: "Catppuccin Dark" },
@@ -56,22 +55,37 @@ export function applyThemeFromStorage(): void {
 	applyTheme(getCurrentTheme());
 }
 
+export function getAllPreferences(): { [key: string]: unknown } {
+    const preferences = localStorage.getItem(preferencesStorageKey) || "{}";
+    return JSON.parse(preferences);
+}
+
+export function setPreference( newPreferences: object ): void {
+    const preferences = getAllPreferences();
+    const mergedPreferences = Object.assign({}, preferences, newPreferences)
+    localStorage.setItem(preferencesStorageKey, JSON.stringify(mergedPreferences));
+}
+
 export function setCheckboxStylePreference(preference: string): void {
-    localStorage.setItem(checkboxStylePreferenceKey, preference);
+    setPreference({checkboxStyle: preference});
     renderApp();
 }
 
 export function getCheckboxStylePreference(): string {
-	return localStorage.getItem(checkboxStylePreferenceKey) || "default";
+    const style = getAllPreferences().checkboxStyle;
+    if (typeof style !== 'string' || style === '') return "default"
+    return style;
 }
 
 export function setTickMarkVisible(hasTick: boolean): void {
-    localStorage.setItem(tickMarkVisibleKey, hasTick.toString());
+    setPreference({tickMarkVisible: hasTick})
     renderApp();
 }
 
 export function getTickMarkVisible(): boolean {
-    return localStorage.getItem(tickMarkVisibleKey) === "true";
+    const visible = getAllPreferences().tickMarkVisible;
+    if (typeof visible !== 'boolean') return true
+    return visible;
 }
 
 export const debug = new Observable(typeof window !== "undefined" && localStorage.getItem(debugStorageKey) === "true");

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -60,30 +60,46 @@ export function getAllPreferences(): { [key: string]: unknown } {
     return JSON.parse(preferences);
 }
 
-export function setPreference( newPreferences: object ): void {
+export function getPreference(key: string): unknown {
+
     const preferences = getAllPreferences();
-    const mergedPreferences = Object.assign({}, preferences, newPreferences)
-    localStorage.setItem(preferencesStorageKey, JSON.stringify(mergedPreferences));
+    const foundItem = preferences[key];
+    if (typeof foundItem === 'undefined') return null;
+    return foundItem;
+}
+
+export function setPreference( key: string, value: unknown, renderImmediate: boolean = true ): void {
+    const preferences = getAllPreferences();
+    preferences[key] = value;
+    localStorage.setItem(preferencesStorageKey, JSON.stringify(preferences));
+    if (renderImmediate) renderApp();
 }
 
 export function setCheckboxStylePreference(preference: string): void {
-    setPreference({checkboxStyle: preference});
-    renderApp();
+    setPreference('checkboxStyle', preference);
 }
 
 export function getCheckboxStylePreference(): string {
-    const style = getAllPreferences().checkboxStyle;
+    const style = getPreference("checkboxStyle");
     if (typeof style !== 'string' || style === '') return "default"
     return style;
 }
 
+export function setTickMarkBorderVisible(hasBorder: boolean): void {
+    setPreference("tickMarkBorderVisible", hasBorder);
+}
+export function getTickMarkBorderVisible(): boolean {
+    const visible = getPreference("tickMarkBorderVisible")
+    if (typeof visible !== 'boolean') return true
+    return visible;
+}
+
 export function setTickMarkVisible(hasTick: boolean): void {
-    setPreference({tickMarkVisible: hasTick})
-    renderApp();
+    setPreference("tickMarkVisible", hasTick);
 }
 
 export function getTickMarkVisible(): boolean {
-    const visible = getAllPreferences().tickMarkVisible;
+    const visible = getPreference("tickMarkVisible")
     if (typeof visible !== 'boolean') return true
     return visible;
 }


### PR DESCRIPTION
"reduce checkbox style" will remove all those awful transitions and "no ticks" will remove all ticks.

Page 1 runs noticeably faster with the reduced checkbox styles. Especially when scripts are fighting one another.

No ticks looks nice. It's a nice perspective, I think.

![image](https://github.com/user-attachments/assets/41cb2f31-1a41-404b-b5f4-fe6556a0dff9)
